### PR TITLE
Fix: handle missing “Decline optional cookies” button in Puppeteer on Lambda

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -125,6 +125,6 @@ export const scrapeEvents = async (
 		enableCursor();
 		logError(err);
 
-		return [];
+		throw err;
 	}
 };

--- a/src/scrapers/graphQLScraper.mjs
+++ b/src/scrapers/graphQLScraper.mjs
@@ -1,7 +1,7 @@
 import chromium from "@sparticuz/chromium";
 import axios from "axios";
 import puppeteer from "puppeteer-core";
-import { SourceTypes } from "../utils/constants.mjs";
+import { PageElements, SourceTypes } from "../utils/constants.mjs";
 import { logError, replaceParamValue } from "../utils/utils.mjs";
 import { htmlScrapeEventByID } from "./htmlScraper.mjs";
 
@@ -20,15 +20,11 @@ const launchBrowser = async (url) => {
 };
 
 const handleDialogWindows = async (page, delayMs) => {
-	await page.click('[role="button"][aria-label="Decline optional cookies"]');
+	(await page.$(PageElements.DeclineCookies))?.click();
 	await new Promise((resolve) => setTimeout(resolve, delayMs));
 	await page.click("body", { force: true });
 	await new Promise((resolve) => setTimeout(resolve, delayMs));
 	await page.keyboard.press("Escape");
-};
-
-const groupSeeMore = async (page) => {
-	await page.click('[role="button"][aria-label="See more"]');
 };
 
 const waitForGraphQLRequest = (page) => {
@@ -127,7 +123,7 @@ export const captureGraphQL = async (url, sourceType) => {
 	const graphqlPromise = waitForGraphQLRequest(page);
 
 	if (sourceType === SourceTypes.Group) {
-		await groupSeeMore(page);
+		await page.click(PageElements.GroupSeeMoreEvents);
 	}
 
 	const graphqlRequest = await scrollUntilGraphQL(

--- a/src/utils/constants.mjs
+++ b/src/utils/constants.mjs
@@ -13,3 +13,8 @@ export const UrlModifiers = Object.freeze({
 	PagePostfix: "/upcoming_hosted_events",
 	EventPrefix: "https://www.facebook.com/events/",
 });
+
+export const PageElements = Object.freeze({
+	DeclineCookies: '[role="button"][aria-label="Decline optional cookies"]',
+	GroupSeeMoreEvents: '[role="button"][aria-label="See more"]',
+});


### PR DESCRIPTION
### Summary
Fixes #1 

### Problem
In version v0.1.2 the `handleDialogWindows()` failed if the "Decline optional cookies* button was not present.

### Changes
- **Updated `handleDialogWindows()`** to check for the *Decline optional cookies* button existence before clicking.
- **Moved element selectors** (e.g. `"[role='button'][aria-label='Decline optional cookies']`) to **separate constants**.
- **Removed the unnecessary `groupSeeMore` function**
- **Modified error handling** in `index.mjs` to ensure that, when an error occurs, it **throws** an exception instead of returning an empty array.

### Testing
**Local Testing**: All changes verified locally, including the element selector refactor.
**AWS Lambda Testing**: Confirmed that `handleDialogWindows()` does not throw on missing elements, crashing the entire process.

