### PR TITLE
Fix: handle changed “See more” button aria-label in Puppeteer

### DIFF
--- a/src/scrapers/graphQLScraper.mjs
+++ b/src/scrapers/graphQLScraper.mjs
@@ -20,7 +20,7 @@ const launchBrowser = async (url) => {
 };
 
 const handleDialogWindows = async (page, delayMs) => {
-	(await page.$(PageElements.DeclineCookies))?.click();
+	await (await page.$(PageElements.DeclineCookies))?.click();
 	await new Promise((resolve) => setTimeout(resolve, delayMs));
 	await page.click("body", { force: true });
 	await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -123,7 +123,7 @@ export const captureGraphQL = async (url, sourceType) => {
 	const graphqlPromise = waitForGraphQLRequest(page);
 
 	if (sourceType === SourceTypes.Group) {
-		await page.click(PageElements.GroupSeeMoreEvents);
+		await (await page.$(PageElements.GroupSeeMoreEvents))?.click();
 	}
 
 	const graphqlRequest = await scrollUntilGraphQL(

--- a/src/scrapers/htmlScraper.mjs
+++ b/src/scrapers/htmlScraper.mjs
@@ -1,7 +1,7 @@
 import axios from "axios";
 import pLimit from "p-limit";
 import { SourceTypes } from "../utils/constants.mjs";
-import { constructUrl, extractJson } from "../utils/utils.mjs";
+import { constructUrl, extractJson, logError } from "../utils/utils.mjs";
 
 export const htmlGetRequest = async (url, options) => {
 	for (let attempt = 1; attempt <= options.httpReqRetries; attempt++) {

--- a/src/utils/constants.mjs
+++ b/src/utils/constants.mjs
@@ -16,5 +16,5 @@ export const UrlModifiers = Object.freeze({
 
 export const PageElements = Object.freeze({
 	DeclineCookies: '[role="button"][aria-label="Decline optional cookies"]',
-	GroupSeeMoreEvents: '[role="button"][aria-label="See more"]',
+	GroupSeeMoreEvents: '[role="button"][aria-label="See more group events"]',
 });


### PR DESCRIPTION
### Summary
Fixes #3 

### Problem
In version v0.1.3 when scraping groups a *See more* button was being clicked by searching for `aria-label` *See more*, but the `aria-label` was changed to *See more group events*.

### Changes
- **Updated `captureGraphQL()`** to check for the *See more* button existence before clicking.
- **Updated `GroupSeeMoreEvents` in `utils/constants.mjs` `PageElements`** to match the new `aria-label`.
- **Added the missing await to the *Decline optional cookies* click call**
- **Added missing import** in `htmlScraper.mjs` for `logError`.

### Testing
✅ **Local Testing**: All changes verified locally.