### PR TITLE
Fix: limit the number of concurrent puppeteer browser launches to one on AWS Lambda instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ const options = {
 	httpReqRetries: 5, // retry failed requests
 	httpReqRetryDelay: 1000, // wait 1s between retries
 	httpReqTimeout: 5000, // timeout each HTTP request after 5s
+	isAWS: true, // if true abide by the rules set by AWS Lambda (max one puppeteer browser instance at a time)
 	outputFile: "events.json", // optionally save results to file
 };
 


### PR DESCRIPTION
### Summary
Fixes #5 

### Problem
In version v0.1.5 the `scrapeEvents()` failed if multiple concurrent sources required browser to launch on AWS Lambda ran instances.

### Changes
- **Added `options.isAWS`** parameter which determines whether the code is being ran on AWS Lambda.
- **Added p-limit `graphQLLimit`** to limit the number of concurrent browsers being launched 1 for AWS Lambda 10 for others.

### Testing
**Local Testing**: All changes verified locally.
**AWS Lambda Testing**: Confirmed that `scrapeEvents()` no longer throws on multiple sources demanding browser launches.

